### PR TITLE
Allow db_instances to recover more than 100 records

### DIFF
--- a/lib/rds_helper.rb
+++ b/lib/rds_helper.rb
@@ -11,7 +11,7 @@ class RDSHelper
   end
 
   def db_instances
-    instances = Array.new
+    instances = []
     @rds_client.describe_db_instances(max_records:100).each do |page|
       instances.concat(page.db_instances)
     end

--- a/lib/rds_helper.rb
+++ b/lib/rds_helper.rb
@@ -12,7 +12,7 @@ class RDSHelper
 
   def db_instances
     instances = []
-    @rds_client.describe_db_instances(max_records:100).each do |page|
+    @rds_client.describe_db_instances(max_records: 100).each do |page|
       instances.concat(page.db_instances)
     end
     instances

--- a/lib/rds_helper.rb
+++ b/lib/rds_helper.rb
@@ -11,7 +11,11 @@ class RDSHelper
   end
 
   def db_instances
-    @rds_client.describe_db_instances.db_instances
+    instances = Array.new
+    @rds_client.describe_db_instances(max_records:100).each do |page|
+      instances.concat(page.db_instances)
+    end
+    instances
   end
 
   def db_clusters


### PR DESCRIPTION
Currently, `db_instances` method of `RDSHelper` class allows only 100 first entries to be listed due to limitations in Ruby SDK. This pull request adds the pagination token to `db_instances` method so if there are more than 100 instances with a `appvia.io` tag, they can be retrieved in one run. Feature has been tested locally. 